### PR TITLE
Change `lightning:` to `lnurl:`

### DIFF
--- a/lnurl-channel.md
+++ b/lnurl-channel.md
@@ -7,7 +7,7 @@ Suppose user has a balance on a certain service which he wishes to turn into an 
 ### Wallet to service interaction flow:
 ![Diagram showing interaction](media/diagrams/lnurl-channel-incoming-1.0.svg "Diagram showing interaction")
 
-1. User scans a LNURL QR code or accesses an `lightning:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
+1. User scans a LNURL QR code or accesses an `lnurl:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 
@@ -38,7 +38,7 @@ Suppose user has a balance on a certain service which he wishes to turn into an 
 ## Wallet to service interaction flow:
 ![Diagram showing interaction](media/diagrams/lnurl-channel-incoming-1.0.svg "Diagram showing interaction")
 
-1. User scans a LNURL QR code or accesses an `lightning:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
+1. User scans a LNURL QR code or accesses an `lnurl:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 

--- a/lnurl-pay.md
+++ b/lnurl-pay.md
@@ -5,7 +5,7 @@
 ### Wallet to service interaction flow:
 ![Diagram showing interaction](media/diagrams/lnurl-pay-1.0.svg "Diagram showing interaction")
 
-1. User scans a LNURL QR code or accesses an `lightning:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
+1. User scans a LNURL QR code or accesses an `lnurl:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 

--- a/lnurl-withdraw.md
+++ b/lnurl-withdraw.md
@@ -7,7 +7,7 @@ Today users are asked to provide a withdrawal Lightning invoice to a service, th
 ### Wallet to service interaction flow:
 ![Diagram showing interaction](media/diagrams/lnurl-withdraw-1.0.svg "Diagram showing interaction")
 
-1. User scans a LNURL QR code or accesses an `lightning:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
+1. User scans a LNURL QR code or accesses an `lnurl:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
 
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 
@@ -84,7 +84,7 @@ Eg:
 	&callback=String
     &balanceCheck=String
 
-This fast LNURL-withdraw method is not to be confused as an alternative to the original LNURL-withdraw, and is designed to be only be used for `lightning:`-type links that work between apps. It is not suitable for QR code implementations.
+This fast LNURL-withdraw method is not to be confused as an alternative to the original LNURL-withdraw, and is designed to be only be used for `lnurl:`-type links that work between apps. It is not suitable for QR code implementations.
 
 If a `LN SERVICE` developer chooses to implement fast LNURL-withdraw in their app, the encoded URL with query params must still return a JSON response containing data that would be sent in step 3. when a GET request is made to it. This is required so as to be backwards-compatible with `LN WALLET`s which have only implemented the original LNURL-withdraw method.
 


### PR DESCRIPTION
This changes the few occurrences of `lightning:` to `lnurl:`, which would close #53.
I can't currently think of a situation in which this would break existing implementations.

This simply allows wallets that implement this change first to override other wallets' behavior:
* On Android, it enables further customization of url scheme handling.
* On iOS, this makes the [url scheme lottery](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app/#Register-Your-URL-Scheme)¹ a little bit less of a nightmare, as new `lnurl:` links will never be opened by wallets that don't support lnurl. I've looked into this and there seems to be literally no way to change url scheme behavior on iOS.

Potential future problem this can (and likely will) cause:
* Wallet developers lagging behind, and users of older wallets not being able to scan QR codes with the new `lnurl:` scheme

I would personally argue that this is a much better problem to have than wallets without lnurl support opening `lightning:LNURL...` links.

¹The only way to force a certain scheme to be opened by a _specific_ app is to register a reverse DNS string with the app, like `com.example.subdomain`, so that links like `scheme:subdomain.example.com` are opened by that app (from my understanding). Otherwise, it seems that currently it just opens the link with the latest app that has been installed (and registered support for that scheme).