### PR TITLE
Allow self-signed certificates for onion addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Once `LNURL` is decoded:
 - If `tag` query parameter is present then this `LNURL` has a special meaning, further actions will be based on `tag` parameter value.
 - Otherwise a GET request should be executed which must return a JSON object containing a `tag` field, further actions will be based on `tag` field value.
 
-## HTTPS or Onion
+## Self-signed certificates for Onion addresses
 
-`LNURL` is acceptable in two forms: either an `https://` clearnet link (no self-signed certificates allowed) or an `http://` v2/v3 onion link.
+`LNURL` links must use `https` at all times, self-signed certificates are only allowed for v2/v3 onion addresses.
 
 ## Fallback scheme
 

--- a/lnurl-pay.md
+++ b/lnurl-pay.md
@@ -10,7 +10,7 @@
 1.1.2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.  
 **Or**   
 1.2.1. User scans/pastes/shares an [internet identifier](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) with `LN WALLET`.  
-1.2.2. `LN WALLET` extracts `domain` and `user` parts from identifier, makes a GET request to `https://<LN SERVICE domain>/.well-known/lnurlp/<user>` endpoint if `domain` is clearnet or `http://<LN SERVICE domain>/.well-known/lnurlp/<user>` if `domain` is onion, an example for `payments@site.com` is GET `https://site.com/.well-known/lnurlp/payments`.  
+1.2.2. `LN WALLET` extracts `domain` and `user` parts from identifier, makes a GET request to `https://<LN SERVICE domain>/.well-known/lnurlp/<user>` endpoint, an example for `payments@site.com` is GET `https://site.com/.well-known/lnurlp/payments`.  
 **Then**  
 2. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 


### PR DESCRIPTION
Previously a plain HTTP was allowed for onion addresses but it turned out that not all clients are happy with this (Android phones prohibit all HTTP traffic for example). As a fix, we now require HTTPS for onion links as well, but also allow self-signed certificates for them.