### PR TITLE
Connect pay and withdraw via optional fields.

### DIFF
--- a/justification.md
+++ b/justification.md
@@ -2,4 +2,4 @@
 
 ## Mutually discoverable pay and withdraw links
 
-`lnurl-pay` may contain a `withdrawLink` in its Json response and likewise `lnurl-withdraw` may contain a `payLink` in its Json response. This is done to recognize a fact that `LN SERVICE` may want to allow both deposits and withdrawals to user account and make related links easily discoverable from each other. When `LN WALLET` sees this it may show a compound item to user which would allow to both deposit and withdraw (and also to show an up-to-date `LN SERVICE` balance if `lnurl-withdraw` contains a `balanceCheck` field).
+`lnurl-pay` may contain a `withdrawLink` in its Json response and likewise `lnurl-withdraw` may contain a `payLink` in its Json response. This is done to recognize a fact that `LN SERVICE` may want to allow both deposits and withdrawals to user account and make related links easily discoverable from each other. When `LN WALLET` sees this it may store and show a compound item to user which would allow to both deposit and withdraw (and also to show an up-to-date `LN SERVICE` balance if `lnurl-withdraw` contains a `balanceCheck` field).

--- a/justification.md
+++ b/justification.md
@@ -1,0 +1,5 @@
+# Justifications for various decisions
+
+## Mutually discoverable pay and withdraw links
+
+`lnurl-pay` may contain a `withdrawLink` in its Json response and likewise `lnurl-withdraw` may contain a `payLink` in its Json response. This is done to recognize a fact that `LN SERVICE` may want to allow both deposits and withdrawals to user account and make related links easily discoverable from each other. When `LN WALLET` sees this it may show a compound item to user which would allow to both deposit and withdraw (and also to show an up-to-date `LN SERVICE` balance if `lnurl-withdraw` contains a `balanceCheck` field).

--- a/lnurl-pay.md
+++ b/lnurl-pay.md
@@ -16,12 +16,13 @@
 
     ```
     {
-        callback: String, // the URL from LN SERVICE which will accept the pay request parameters
-        maxSendable: MilliSatoshi, // max amount LN SERVICE is willing to receive
-        minSendable: MilliSatoshi, // min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
-        metadata: String, // metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
-        commentAllowed: Number, // optional number of characters accepted for the `comment` query parameter on subsequent callback, defaults to 0 if not provided. (no comment allowed)
-        tag: "payRequest" // type of LNURL
+        callback: String, // The URL from LN SERVICE which will accept the pay request parameters
+        maxSendable: MilliSatoshi, // Max amount LN SERVICE is willing to receive
+        minSendable: MilliSatoshi, // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
+        metadata: String, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
+        commentAllowed: Number, // Optional number of characters accepted for the `comment` query parameter on subsequent callback, defaults to 0 if not provided. (no comment allowed)
+        withdrawLink: String, // Optional lnurl-withdraw link (for explanation see justification.md)
+        tag: "payRequest" // Type of LNURL
     }
     ```
     or

--- a/lnurl-withdraw.md
+++ b/lnurl-withdraw.md
@@ -15,12 +15,13 @@ Today users are asked to provide a withdrawal Lightning invoice to a service, th
     ```
     {
         tag: "withdrawRequest", // type of LNURL
-        callback: String, // the URL which LN SERVICE would accept a withdrawal Lightning invoice as query parameter
-        k1: String, // random or non-random string to identify the user's LN WALLET when using the callback URL
+        callback: String, // The URL which LN SERVICE would accept a withdrawal Lightning invoice as query parameter
+        k1: String, // Random or non-random string to identify the user's LN WALLET when using the callback URL
         defaultDescription: String, // A default withdrawal invoice description
         minWithdrawable: Integer, // Min amount (in millisatoshis) the user can withdraw from LN SERVICE, or 0
         maxWithdrawable: Integer, // Max amount (in millisatoshis) the user can withdraw from LN SERVICE, or equal to minWithdrawable if the user has no choice over the amounts
         balanceCheck: String, // Optional, an URL that can be called next time the wallet wants to perform a balance check, the call will be the same as performed in this step and the expected response is the same
+        payLink: String, // Optional lnurl-pay link (for explanation see justification.md)
     }
     ```
     or


### PR DESCRIPTION
This allows wallets to easily create a compound item consisting of static `pay` and `withdraw` links internally which together act as interface to a service. Such an item can also show an up to date balance if `withdraw` link has a `balanceCheck` provided.