### PR TITLE
Mandate compressed key in auth, clarify encodings

### DIFF
--- a/04.md
+++ b/04.md
@@ -14,7 +14,7 @@ A special `linkingKey` can be used to login user to a service or authorise sensi
 
 When creating an `LNURL-auth` handler `LN SERVICE` must include in it a `k1` query parameter consisting of randomly generated 32 bytes of data as well as optional `action` enum, an example is `https://site.com?tag=login&k1=hex(32 bytes of random data)&action=login`.
 
-Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, it should take `k1`, `key` and a DER-encoded `sig` and verify the signature using `secp256k1`. Once signature is successfully verified a user provided `key` can be used as identifier and may be stored in a session, database or however `LN SERVICE` sees fit.
+Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, it MUST take `k1`, compressed (65-byte) `secp256k1` public `key` encoded as hex, and a DER-encoded ECDSA `sig` and verify the signature using `secp256k1`. Once signature is successfully verified a user provided `key` can be used as identifier and may be stored in a session, database or however `LN SERVICE` sees fit.
 
 `LN SERVICE` must make sure that unexpected `k1`s are not accepted: it is strongly advised for `LN SERVICE` to have a cache of unused `k1`s, only proceed with verification of `k1`s present in that cache and remove used `k1`s on successful auth attempts.
 

--- a/04.md
+++ b/04.md
@@ -14,7 +14,7 @@ A special `linkingKey` can be used to login user to a service or authorise sensi
 
 When creating an `LNURL-auth` handler `LN SERVICE` must include in it a `k1` query parameter consisting of randomly generated 32 bytes of data as well as optional `action` enum, an example is `https://site.com?tag=login&k1=hex(32 bytes of random data)&action=login`.
 
-Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, it MUST take `k1`, compressed (65-byte) `secp256k1` public `key` encoded as hex, and a DER-encoded ECDSA `sig` and verify the signature using `secp256k1`. Once signature is successfully verified a user provided `key` can be used as identifier and may be stored in a session, database or however `LN SERVICE` sees fit.
+Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, it MUST take `k1`, compressed (33-byte) `secp256k1` public `key` encoded as hex, and a DER-hex-encoded ECDSA `sig` and verify the signature using `secp256k1`. Once signature is successfully verified a user provided `key` can be used as identifier and may be stored in a session, database or however `LN SERVICE` sees fit.
 
 `LN SERVICE` must make sure that unexpected `k1`s are not accepted: it is strongly advised for `LN SERVICE` to have a cache of unused `k1`s, only proceed with verification of `k1`s present in that cache and remove used `k1`s on successful auth attempts.
 


### PR DESCRIPTION
This mandates that `key` is compressed and explains its precise encoding.
It also clarifies that the signature is ECDSA (as opposed to schnorr or BLS) and mandates signature verification.