### PR TITLE
Fix Blixt Wallet not supporting LUD-05 but supports LUD-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are all the individual documents describing each small piece of protocol t
 | [02](02.md) | `channelRequest` base spec.                                 | [BLW][blw] [Breez][breez] [Zap Android][zap] [Zap Desktop][zap] [Zeus][zeus] |
 | [03](03.md) | `withdrawRequest` base spec.                                | [BLW][blw] [Blixt][blixt] [BlueWallet][bluewallet] [Breez][breez] [coinos][coinos] [LNbits][lnbits] [@lntxbot][lntxbot] [Muun][muun] [Phoenix][phoenix] [ShockWallet][shockwallet] [ThunderHub][thunderhub] [Wallet of Satoshi][wos] [Zap Android][zap] [Zap iOS][zap] [Zap Desktop][zap] [ZEBEDEE][zbd] [ZBD Telegram][zbd] [ZBD Discord][zbd] [ZBD Extension][zbd] [Zeus][zeus] |
 | [04](04.md) | Auth base spec.                                             | [BLW][blw] [Blixt][blixt] [coinos][coinos] [LNbits][lnbits] [@lntxbot][lntxbot] [Phoenix][phoenix] [ThunderHub][thunderhub] [Zap Desktop][zap] [Zeus][zeus] |
-| [05](05.md) | BIP32-based seed generation for auth protocol.              | [BLW][blw] [Blixt][blixt] |
+| [05](05.md) | BIP32-based seed generation for auth protocol.              | [BLW][blw] |
 | [06](06.md) | `payRequest` base spec.                                     | [BLW][blw] [Blixt][blixt] [BlueWallet][bluewallet] [Breez][breez] [coinos][coinos] [LNbits][lnbits] [@lntxbot][lntxbot] [Phoenix][phoenix] [ShockWallet][shockwallet] [ThunderHub][thunderhub] [Wallet of Satoshi][wos] [Zap Android][zap] [ZEBEDEE][zbd] [ZBD Telegram][zbd] [ZBD Discord][zbd] [ZBD Extension][zbd] [Zeus][zeus] |
 | [07](07.md) | `hostedChannelRequest` base spec.                           | [BLW][blw] |
 | [08](08.md) | Fast `withdrawRequest`.                                     | [BLW][blw] [@lntxbot][lntxbot] [ZBD Extension][zbd] |
@@ -17,7 +17,7 @@ These are all the individual documents describing each small piece of protocol t
 | [10](10.md) | `aes` success action in `payRequest`.                       | [BLW][blw] [Blixt][blixt] [BlueWallet][bluewallet] [Breez][breez] [coinos][coinos] [LNbits][lnbits] [@lntxbot][lntxbot] [Phoenix][phoenix] [ShockWallet][shockwallet] [ThunderHub][thunderhub] [Wallet of Satoshi][wos] [Zap Android][zap] [Zeus][zeus] |
 | [11](11.md) | Disposable and storeable `payRequest`s.                     | [BLW][blw] [ZBD Extension][zbd] [Zap Android][zap] |
 | [12](12.md) | Comments in `payRequest`.                                   | [Blixt][blixt] [Breez][breez] [LNbits][lnbits] [@lntxbot][lntxbot] [Phoenix][phoenix] [ThunderHub][thunderhub] [ThunderHub][thunderhub] [Wallet of Satoshi][wos] [Zap Android][zap] [ZEBEDEE][zbd] [ZBD Telegram][zbd] [ZBD Discord][zbd] [ZBD Extension][zbd] [Zeus][zeus] |
-| [13](13.md) | LND-based seed generation for auth protocol.                | |
+| [13](13.md) | LND-based seed generation for auth protocol.                | [Blixt][blixt] |
 | [14](14.md) | `balanceCheck`: reusable `withdrawRequest`s.                | [@lntxbot][lntxbot] [LNbits][lnbits] |
 | [15](15.md) | `balanceNotify`: services hurrying up the withdraw process. | [@lntxbot][lntxbot] [LNbits][lnbits] |
 | [16](16.md) | Paying to static internet identifiers.                      | [@lntxbot][lntxbot] [LNbits][lnbits] |


### PR DESCRIPTION
Blixt Wallet uses the "node message signing" way of deriving linkingKey
in the auth protocol.