### PR TITLE
Describe in LUD-13's title that it's about the common "signMessage" API

### DIFF
--- a/13.md
+++ b/13.md
@@ -1,4 +1,4 @@
-LUD-13: LND-based seed generation for auth protocol.
+LUD-13: `signMessage`-based seed generation for auth protocol.
 ====================================================
 
 `author: akumaigorodski` `author: fiatjaf` `author: hampus_s` `discussion: https://t.me/lnurl/5155`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These are all the individual documents describing each small piece of protocol t
 | [10](10.md) | `aes` success action in `payRequest`.                       | [BLW][blw] [Blixt][blixt] [BlueWallet][bluewallet] [Breez][breez] [coinos][coinos] [LNbits][lnbits] [@lntxbot][lntxbot] [Phoenix][phoenix] [ShockWallet][shockwallet] [ThunderHub][thunderhub] [Wallet of Satoshi][wos] [Zap Android][zap] [Zeus][zeus] |
 | [11](11.md) | Disposable and storeable `payRequest`s.                     | [BLW][blw] [ZBD Extension][zbd] [Zap Android][zap] |
 | [12](12.md) | Comments in `payRequest`.                                   | [Blixt][blixt] [Breez][breez] [LNbits][lnbits] [@lntxbot][lntxbot] [Phoenix][phoenix] [ThunderHub][thunderhub] [ThunderHub][thunderhub] [Wallet of Satoshi][wos] [Zap Android][zap] [ZEBEDEE][zbd] [ZBD Telegram][zbd] [ZBD Discord][zbd] [ZBD Extension][zbd] [Zeus][zeus] |
-| [13](13.md) | LND-based seed generation for auth protocol.                | [Blixt][blixt] [Zeus][zeus] |
+| [13](13.md) | `signMessage`-based seed generation for auth protocol.      | [Blixt][blixt] [Zeus][zeus] |
 | [14](14.md) | `balanceCheck`: reusable `withdrawRequest`s.                | [@lntxbot][lntxbot] [LNbits][lnbits] |
 | [15](15.md) | `balanceNotify`: services hurrying up the withdraw process. | [@lntxbot][lntxbot] [LNbits][lnbits] |
 | [16](16.md) | Paying to static internet identifiers.                      | [@lntxbot][lntxbot] [LNbits][lnbits] [ZEBEDEE][zbd] [ZBD Telegram][zbd] [ZBD Discord][zbd] [ZBD Extension][zbd] |


### PR DESCRIPTION
While the purpose of LUD-13 was to have a standard way for lnd-based wallets to implement LNURL-auth, Zeus is now using the node message signature method for generating the hashingKey for all their backends (lnd, c-lightning and eclair).