### PR TITLE
Remove `withdrawLink` from LNURL-PAY JSON

### DIFF
--- a/19.md
+++ b/19.md
@@ -1,4 +1,4 @@
-LUD-19: Mutually discoverable pay and withdraw links.
+LUD-19: Pay link discoverable from withdraw link.
 =====================================================
 
 `author: akumaigorodski` `discussion: https://t.me/lnurl/12568`
@@ -7,26 +7,11 @@ LUD-19: Mutually discoverable pay and withdraw links.
 
 ## Merging "pay" and "withdraw" related to a same `SERVICE` in a `WALLET`
 
-LNURL-pay may contain a `withdrawLink` in its JSON response and likewise LNURL-withdraw may contain a `payLink` in its JSON response. This is done to recognize a fact that `SERVICE` may want to allow both deposits and withdrawals to user account and make related links easily discoverable from each other.
+LNURL-withdraw may contain a `payLink` in its JSON response. This is done to recognize a fact that `SERVICE` may want to allow both deposits and withdrawals to user account and as such make a static payment link easily discoverable from withdraw link.
 
 When `WALLET` sees this it may store and show a compound item to user which would allow to both deposit and withdraw (and also to show an up-to-date `SERVICE` balance if LNURL-withdraw contains a `balanceCheck` field).
 
-Modifications required in `SERVICE` JSON responses:
-
-To the first callback of LNURL-pay:
-
-```diff
- {
-   callback: String,
-   maxSendable: MilliSatoshi,
-   minSendable: MilliSatoshi,
-   metadata: String,
-   tag: "payRequest",
-+  withdrawLink: String,
- }
-```
-
-To the callback of LNURL-withdraw:
+Modification required in `SERVICE` callback JSON of LNURL-withdraw:
 
 ```diff
  {
@@ -41,4 +26,4 @@ To the callback of LNURL-withdraw:
  }
 ```
 
-Both `withdrawLink` and `payLink` are raw URLs (not bech32-encoded).
+`payLink` is raw URL (not bech32-encoded).


### PR DESCRIPTION
Since LNURL-PAY is static by design it may get discovered by many entities over time. Next, if LNURL-PAY were to contain `withdrawLink` in its JSON then all those entities would be able to withdraw funds from related account which is most likely undesirable. As such we restrict discoverability from WITHDRAW to PAY only, but not vice versa.